### PR TITLE
init: 초기 라우터 설정

### DIFF
--- a/client/src/study-times/src/App.vue
+++ b/client/src/study-times/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <v-app>
     <v-main>
-      <HelloWorld/>
+      <router-view></router-view>
     </v-main>
   </v-app>
 </template>

--- a/client/src/study-times/src/main.js
+++ b/client/src/study-times/src/main.js
@@ -2,9 +2,11 @@ import { createApp } from 'vue'
 import App from './App.vue'
 import vuetify from './plugins/vuetify'
 import { loadFonts } from './plugins/webfontloader'
+import router from './router'
 
 loadFonts()
 
 createApp(App)
   .use(vuetify)
+  .use(router)
   .mount('#app')

--- a/client/src/study-times/src/router/index.js
+++ b/client/src/study-times/src/router/index.js
@@ -1,0 +1,19 @@
+import * as VueRouter from 'vue-router'
+import * as Names from './names'
+
+// https://router.vuejs.org/guide/advanced/meta.html
+// lazy loading routes
+const router = VueRouter.createRouter({
+  // https://router.vuejs.org/guide/advanced/meta.html
+  history: VueRouter.createWebHistory(),
+  routes: [
+    {
+      path: '/mypage',
+      name: Names.MyPage,
+      component: () => import('../views/mypage/index.vue')
+    }
+  ],
+})
+
+export { Names }
+export default router

--- a/client/src/study-times/src/router/names/index.js
+++ b/client/src/study-times/src/router/names/index.js
@@ -1,0 +1,1 @@
+export const MyPage = Symbol('mypage')

--- a/client/src/study-times/src/views/mypage/index.vue
+++ b/client/src/study-times/src/views/mypage/index.vue
@@ -1,0 +1,27 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col>
+        email
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col>
+        settings
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col>
+        times
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col>
+        탈퇴
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script setup>
+</script>


### PR DESCRIPTION
Router-link 를 사용할 때 path 보다는 name을 사용하는 것이 
초기 url 변경사항에 유연하게 대처할 수 있다고 판단

name은 코드 중복이나 실수를 방지하기 위해 별도의 symbol 타입을 사용